### PR TITLE
Relaxes order rules.

### DIFF
--- a/src/order.js
+++ b/src/order.js
@@ -1,10 +1,3 @@
 module.exports = {
-    'order/order': [
-        'custom-properties',
-        'dollar-variables',
-        'rules',
-        'declarations',
-        'at-rules'
-    ],
     'order/properties-alphabetical-order': true
 };


### PR DESCRIPTION
Upon further testing with existing projects, the plugin was having difficulty differentiating between Sass at-rules and CSS at-rules, making them orderable independently difficult.

Removing the rule until plugin advances in options.